### PR TITLE
Require grf >= 2.2.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,12 +33,6 @@ jobs:
           # Install OSX deps manually
           sudo Rscript -e "install.packages(c('survival', 'glmnet', 'grf'), type = 'mac.binary')"
 
-      - name: Tmp devel GRF install
-        run: |
-          git clone http://github.com/grf-labs/grf.git && cd grf/r-package/grf
-          sudo Rscript -e "install.packages('RcppEigen', type = 'mac.binary')"
-          R CMD build . && R CMD install .
-
       - name: Test
         working-directory: r-package/survlearners
         run: |

--- a/r-package/survlearners/DESCRIPTION
+++ b/r-package/survlearners/DESCRIPTION
@@ -21,5 +21,5 @@ Suggests:
 VignetteBuilder: knitr
 Imports:
     glmnet,
-    grf,
+    grf (>= 2.2.0),
     survival


### PR DESCRIPTION
Require the latest grf (with the updated IPCW-type prediction option in survival forest) now that the latest grf release is on CRAN.

(the online build should pass in a few days when latest version is on cran servers. closes #31 )